### PR TITLE
DateTime bugfix and Raven Constants correction

### DIFF
--- a/src/Hangfire.Raven.Tests/RavenJobQueueMonitoringApiFacts.cs
+++ b/src/Hangfire.Raven.Tests/RavenJobQueueMonitoringApiFacts.cs
@@ -74,9 +74,9 @@ namespace Hangfire.Raven.Tests
         {
             UseStorage(storage =>
             {
-                var mongoJobQueueMonitoringApi = CreateRavenJobQueueMonitoringApi(storage);
+                var ravenJobQueueMonitoringApi = CreateRavenJobQueueMonitoringApi(storage);
 
-                var enqueuedJobIds = mongoJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10);
+                var enqueuedJobIds = ravenJobQueueMonitoringApi.GetEnqueuedJobIds(QueueName1, 0, 10);
 
                 Assert.Empty(enqueuedJobIds);
             });

--- a/src/Hangfire.Raven/DistributedLocks/RavenDistributedLockException.cs
+++ b/src/Hangfire.Raven/DistributedLocks/RavenDistributedLockException.cs
@@ -3,7 +3,7 @@
 namespace Hangfire.Raven.DistributedLocks
 {
     /// <summary>
-    /// Represents exceptions for distributed lock implementation for MongoDB
+    /// Represents exceptions for distributed lock implementation for RavenDB
     /// </summary>
     [Serializable]
     public class RavenDistributedLockException : Exception

--- a/src/Hangfire.Raven/Extensions/IDocumentSessionExtensions.cs
+++ b/src/Hangfire.Raven/Extensions/IDocumentSessionExtensions.cs
@@ -57,7 +57,7 @@ namespace Hangfire.Raven.Extensions {
 
         private static DateTime? GetExpiry(IMetadataDictionary metadata) {
             if (metadata.ContainsKey(Constants.Documents.Metadata.Expires))
-                return DateTime.Parse(metadata[Constants.Documents.Metadata.Expires].ToString());
+                return DateTime.Parse(metadata[Constants.Documents.Metadata.Expires].ToString()).ToUniversalTime();
             else
                 return null;
         }

--- a/src/Hangfire.Raven/Storage/RavenStorageExtensions.cs
+++ b/src/Hangfire.Raven/Storage/RavenStorageExtensions.cs
@@ -1,23 +1,25 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
 using Hangfire.Raven.Extensions;
+using Raven.Client;
 using Raven.Client.Documents.Session;
 
 namespace Hangfire.Raven.Storage {
     public static class RavenServerStorageExtensions
     {
-        public static void AddExpire<T>(this IAsyncAdvancedSessionOperations advanced, T obj, DateTime dateTime)
+        public static void AddExpire<T>(this IAdvancedSessionOperations advanced, T obj, DateTime dateTime)
         {
-            advanced.GetMetadataFor(obj)["@expires"] = dateTime;
+            advanced.GetMetadataFor(obj)[Constants.Documents.Metadata.Expires] = dateTime;
         }
-        public static void RemoveExpire<T>(this IAsyncAdvancedSessionOperations advanced, T obj)
+
+        public static void RemoveExpire<T>(this IAdvancedSessionOperations advanced, T obj)
         {
-            advanced.GetMetadataFor(obj).Remove("Raven-Expiration-Date");
+            advanced.GetMetadataFor(obj).Remove(Constants.Documents.Metadata.Expires);
         }
-        public static DateTime? GetExpire<T>(this IAsyncAdvancedSessionOperations advanced, T obj)
+        public static DateTime? GetExpire<T>(this IAdvancedSessionOperations advanced, T obj)
         {
-            if (advanced.GetMetadataFor(obj).TryGetValue("Raven-Expiration-Date", out object dateTime)) {
-                return (DateTime)dateTime;
+            if (advanced.GetMetadataFor(obj).TryGetValue(Constants.Documents.Metadata.Expires, out object dateTime)) {
+                return DateTime.Parse(dateTime.ToString()).ToUniversalTime();
             }
             return null;
         }


### PR DESCRIPTION
Hi, just some fixes I've made on top of your RavenDB 4 branch.

It seems that DateTime.Parse defaults to a DateTime in the local timezone (HangFire stores them all in UTC).

Also fixed up the constants used for the expire metadata string.